### PR TITLE
Use python-dateutil instead of py-dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
 	zip_safe = False,
 	include_package_data = True,
 	packages=find_packages(),
-	install_requires=['py-dateutil','thumbor','boto']
+	install_requires=['python-dateutil','thumbor','boto']
 )


### PR DESCRIPTION
[python-dateutil](https://pypi.python.org/pypi/python-dateutil/2.4.2) is more actively maintained than [py-dateutil](https://pypi.python.org/pypi/py-dateutil/2.2).