### PR TITLE
allow additional boto configuration for eg. dev-hosts, ports etc

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,3 +52,12 @@ Additional Configuration values used:
     #E.g.
     #http://your-thumbor.com/unsafe/filters:watermark(http://example.com/watermark.png,0,0,50)/s3_bucket/photo.jpg
     AWS_ENABLE_HTTP_LOADER = True or False (Default: False)
+
+
+    # Optional additional configuration for the Boto-Client used to access S3.
+    # see http://boto.readthedocs.org/en/latest/ref/s3.html?highlight=boto.s3.connection.s3connection#boto.s3.connection.S3Connection
+    # for all available config options
+    BOTO_CONFIG = {
+        'host': 'fakes3.local.dev',
+        'is_secure': False
+        }

--- a/tc_aws/__init__.py
+++ b/tc_aws/__init__.py
@@ -12,3 +12,5 @@ Config.define('S3_ALLOWED_BUCKETS', False, 'List of allowed bucket to be requete
 Config.define('AWS_ACCESS_KEY', None, 'AWS Access key, if None use environment AWS_ACCESS_KEY_ID', 'AWS')
 Config.define('AWS_SECRET_KEY', None, 'AWS Secret key, if None use environment AWS_SECRET_ACCESS_KEY', 'AWS')
 Config.define('AWS_ROLE_BASED_CONNECTION', False, 'EC2 instance can use role that does not require AWS_ACCESS_KEY see http://docs.aws.amazon.com/IAM/latest/UserGuide/roles-usingrole-ec2instance.html', 'AWS')
+
+Config.define('BOTO_CONFIG', None, 'Additional Boto options for configuring S3 access (see http://boto.readthedocs.org/en/latest/ref/s3.html?highlight=boto.s3.connection.s3connection#boto.s3.connection.S3Connection)')

--- a/tc_aws/connection.py
+++ b/tc_aws/connection.py
@@ -7,12 +7,17 @@ connection = None
 def get_connection(context):
     conn = connection
     if conn is None:
-        if context.config.AWS_ROLE_BASED_CONNECTION:
-            conn = S3Connection()
-        else:
-            conn = S3Connection(
-                context.config.AWS_ACCESS_KEY,
-                context.config.AWS_SECRET_KEY
-            )
+        boto_opts = {}
+
+        if context.config.AWS_ROLE_BASED_CONNECTION==False:
+            boto_opts.update({
+                'aws_access_key_id'    : context.config.AWS_ACCESS_KEY,
+                'aws_secret_access_key': context.config.AWS_SECRET_KEY,
+                })
+
+        if context.config.BOTO_CONFIG:
+            boto_opts.update(context.config.BOTO_CONFIG)
+
+        conn = S3Connection(**boto_opts)
 
     return conn


### PR DESCRIPTION
We use the S3-Backend with a Fakes3 in local dev environments. I added an option to allow more specific setups like this to configure the Boto-Connection (with the parameters available in http://boto.readthedocs.org/en/latest/ref/s3.html?highlight=boto.s3.connection.s3connection#boto.s3.connection.S3Connection).

