### PR TITLE
dont set a loader bucket in config

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,8 @@ Additional Configuration values used:
     # list of allowed buckets for the s3_loader
     S3_ALLOWED_BUCKETS = []
 
-
+    # alternatively: set a fixed bucket, no need for bucket name in Image-Path
+    S3_LOADER_BUCKET = 'thumbor-images'
 
     # configuration settings specific for the storages
 

--- a/tc_aws/__init__.py
+++ b/tc_aws/__init__.py
@@ -2,7 +2,7 @@
 from thumbor.config import Config
 Config.define('STORAGE_BUCKET', 'thumbor-images','S3 bucket for Storage', 'S3')
 Config.define('RESULT_STORAGE_BUCKET', 'thumbor-result', 'S3 bucket for result Storage', 'S3')
-Config.define('S3_LOADER_BUCKET','thumbor-images','S3 bucket for loader', 'S3')
+Config.define('S3_LOADER_BUCKET',None,'S3 bucket for loader', 'S3')
 Config.define('RESULT_STORAGE_AWS_STORAGE_ROOT_PATH','', 'S3 path prefix', 'S3')
 Config.define('STORAGE_EXPIRATION_SECONDS', 3600, 'S3 expiration', 'S3')
 Config.define('S3_STORAGE_SSE', False, 'S3 encriptipon key', 'S3')


### PR DESCRIPTION
This is a suggestion which would have made our start with tc_aws easier: to allow people to chose a bucket via the Thumbor-Image-URL, dont set a fixed loader bucket. We only found this setting when looking through the source code, when we couldnt manage to get one of our images loaded.

If you do want to keep the default value (eg for symmetry with STORAGE_BUCKET), then it would be helpful to mention the setting in the Readme.md like in this PR.