### PR TITLE
Result_storage with the option to store metadata

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ Installation
 Origin story
 ------------
 
-This is a fork of https://github.com/willtrking/thumbor_aws ; as this repository was not maintained anymore, 
+This is a fork of https://github.com/willtrking/thumbor_aws ; as this repository was not maintained anymore,
 we decided to maintain it under the ``thumbor-community`` organisation.
 
 Features
@@ -55,6 +55,8 @@ Additional Configuration values used:
 
     RESULT_STORAGE_BUCKET = 'thumbor-images'
     RESULT_STORAGE_AWS_STORAGE_ROOT_PATH = 'result'
+    # It stores metadata like content-type on the result object
+    RESULT_STORAGE_S3_STORE_METADATA = False
 
     STORAGE_EXPIRATION_SECONDS
 

--- a/tc_aws/__init__.py
+++ b/tc_aws/__init__.py
@@ -15,7 +15,7 @@ Config.define('STORAGE_EXPIRATION_SECONDS',             3600,               'S3 
 Config.define('S3_STORAGE_SSE',                         False,              'S3 encriptipon key', 'S3')
 Config.define('S3_STORAGE_RRS',                         False,              'S3 redundency', 'S3')
 Config.define('S3_ALLOWED_BUCKETS',                     False,              'List of allowed bucket to be requeted', 'S3')
-Config.define('S3_STORE_METADATA',                      False,              'S3 store result with metadata', 'S3')
+Config.define('RESULT_STORAGE_S3_STORE_METADATA',       False,              'S3 store result with metadata', 'S3')
 
 Config.define('AWS_ACCESS_KEY',                         None,               'AWS Access key, if None use environment AWS_ACCESS_KEY_ID', 'AWS')
 Config.define('AWS_SECRET_KEY',                         None,               'AWS Secret key, if None use environment AWS_SECRET_ACCESS_KEY', 'AWS')

--- a/tc_aws/__init__.py
+++ b/tc_aws/__init__.py
@@ -15,6 +15,7 @@ Config.define('STORAGE_EXPIRATION_SECONDS',             3600,               'S3 
 Config.define('S3_STORAGE_SSE',                         False,              'S3 encriptipon key', 'S3')
 Config.define('S3_STORAGE_RRS',                         False,              'S3 redundency', 'S3')
 Config.define('S3_ALLOWED_BUCKETS',                     False,              'List of allowed bucket to be requeted', 'S3')
+Config.define('S3_STORE_METADATA',                      False,              'S3 store result with metadata', 'S3')
 
 Config.define('AWS_ACCESS_KEY',                         None,               'AWS Access key, if None use environment AWS_ACCESS_KEY_ID', 'AWS')
 Config.define('AWS_SECRET_KEY',                         None,               'AWS Secret key, if None use environment AWS_SECRET_ACCESS_KEY', 'AWS')

--- a/tc_aws/aws/storage.py
+++ b/tc_aws/aws/storage.py
@@ -38,6 +38,10 @@ class AwsStorage():
         file_key=Key(self.storage)
         file_key.key=abspath
 
+        if self.context.config.S3_STORE_METADATA:
+            for k, v in self.context.request_handler._headers.iteritems():
+                file_key.set_metadata(k, v)
+
         file_key.set_contents_from_string(bytes,
             encrypt_key=self.context.config.get('S3_STORAGE_SSE', ''),         #TODO: fix config prefix
             reduced_redundancy=self.context.config.get('S3_STORAGE_RRS', '')   #TODO: fix config prefix
@@ -51,7 +55,6 @@ class AwsStorage():
         if not file_key or self.is_expired(file_key):
             logger.debug("[STORAGE] s3 key not found at %s" % file_abspath)
             return None
-
         return file_key.read()
 
     def normalize_path(self, path):

--- a/tc_aws/aws/storage.py
+++ b/tc_aws/aws/storage.py
@@ -38,7 +38,7 @@ class AwsStorage():
         file_key=Key(self.storage)
         file_key.key=abspath
 
-        if self.context.config.S3_STORE_METADATA:
+        if self.config_prefix is 'RESULT_STORAGE' and self._get_config('S3_STORE_METADATA'):
             for k, v in self.context.request_handler._headers.iteritems():
                 file_key.set_metadata(k, v)
 

--- a/vows/result_storage_vows.py
+++ b/vows/result_storage_vows.py
@@ -4,7 +4,7 @@
 from pyvows import Vows, expect
 
 from thumbor.context import Context
-from thumbor.config import Config
+from tc_aws import Config
 from fixtures.storage_fixture import IMAGE_BYTES, get_server
 
 from boto.s3.connection import S3Connection
@@ -16,6 +16,9 @@ s3_bucket = 'thumbor-images-test'
 
 class Request(object):
   url = None
+
+class RequestHandler(object):
+  _headers = {'Content-Type': 'image/webp', 'Some-Other-Header': 'doge-header'}
 
 @Vows.batch
 class S3ResultStorageVows(Vows.Context):
@@ -61,6 +64,30 @@ class S3ResultStorageVows(Vows.Context):
 
     def should_have_proper_bytes(self, topic):
       expect(topic).to_equal(IMAGE_BYTES)
+
+  class CanGetImageWithMetadata(Vows.Context):
+    @mock_s3
+    def topic(self):
+      self.conn = S3Connection()
+      self.conn.create_bucket(s3_bucket)
+
+      config = Config(RESULT_STORAGE_BUCKET=s3_bucket, S3_STORE_METADATA=True)
+      ctx = Context(config=config, server=get_server('ACME-SEC'))
+      ctx.request_handler = RequestHandler()
+      ctx.request = Request
+      ctx.request.url = 'my-image-meta.jpg'
+
+      storage = Storage(ctx)
+      storage.put(IMAGE_BYTES)
+
+      file_abspath = storage.normalize_path(ctx.request.url)
+      file_key = storage.storage.get_key(file_abspath)
+      return file_key.content_type, file_key.metadata, file_key.read()
+
+    def should_have_proper_bytes(self, topic):
+      expect(topic[0]).to_include('image/webp')
+      expect(topic[1]).to_include('some-other-header')
+      expect(topic[2]).to_equal(IMAGE_BYTES)
 
   class HandlesStoragePrefix(Vows.Context):
     @mock_s3

--- a/vows/result_storage_vows.py
+++ b/vows/result_storage_vows.py
@@ -71,7 +71,7 @@ class S3ResultStorageVows(Vows.Context):
       self.conn = S3Connection()
       self.conn.create_bucket(s3_bucket)
 
-      config = Config(RESULT_STORAGE_BUCKET=s3_bucket, S3_STORE_METADATA=True)
+      config = Config(RESULT_STORAGE_BUCKET=s3_bucket, RESULT_STORAGE_S3_STORE_METADATA=True)
       ctx = Context(config=config, server=get_server('ACME-SEC'))
       ctx.request_handler = RequestHandler()
       ctx.request = Request


### PR DESCRIPTION
This will add to aws, the ability to store metadata with the object.
It makes easy for any gateway to respond direct from S3.
