### PR TITLE
fixing pylint warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,22 +3,26 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = 'tc_aws',
-    version = "1.1.0",
-    description = 'Thumbor AWS extensions',
-    author = 'William King',
-    author_email = 'willtrking@gmail.com',
-    zip_safe = False,
-    include_package_data = True,
+    name='tc_aws',
+    version="1.1.0",
+    description='Thumbor AWS extensions',
+    author='William King',
+    author_email='willtrking@gmail.com',
+    zip_safe=False,
+    include_package_data=True,
     packages=find_packages(),
-    install_requires=['python-dateutil','thumbor','boto'],
+    install_requires=[
+        'python-dateutil',
+        'thumbor',
+        'boto'
+    ],
     extras_require={
         'tests': [
             'pyvows',
             'coverage',
             'tornado_pyvows',
             'moto',
-			'mock',
+            'mock',
         ],
     },
 )

--- a/tc_aws/aws/connection.py
+++ b/tc_aws/aws/connection.py
@@ -4,15 +4,16 @@ from boto.s3.connection import S3Connection
 
 connection = None
 
+
 def get_connection(context):
     global connection
 
     if connection is None:
         boto_opts = {}
 
-        if context.config.AWS_ROLE_BASED_CONNECTION==False:
+        if context.config.AWS_ROLE_BASED_CONNECTION is False:
             boto_opts.update({
-                'aws_access_key_id'    : context.config.AWS_ACCESS_KEY,
+                'aws_access_key_id': context.config.AWS_ACCESS_KEY,
                 'aws_secret_access_key': context.config.AWS_SECRET_KEY,
                 })
 

--- a/tc_aws/aws/storage.py
+++ b/tc_aws/aws/storage.py
@@ -14,6 +14,7 @@ from dateutil.parser import parse as parse_ts
 
 from connection import get_connection
 
+
 class AwsStorage():
 
     @property
@@ -25,7 +26,7 @@ class AwsStorage():
         self.context = context
         self.storage = self.__get_s3_bucket()
 
-    def _get_config(self, config_key, default = None):
+    def _get_config(self, config_key, default=None):
         return getattr(self.context.config, '%s_%s' % (self.config_prefix, config_key))
 
     def __get_s3_bucket(self):
@@ -35,16 +36,17 @@ class AwsStorage():
         )
 
     def set(self, bytes, abspath):
-        file_key=Key(self.storage)
-        file_key.key=abspath
+        file_key = Key(self.storage)
+        file_key.key = abspath
 
         if self.config_prefix is 'RESULT_STORAGE' and self._get_config('S3_STORE_METADATA'):
             for k, v in self.context.request_handler._headers.iteritems():
                 file_key.set_metadata(k, v)
 
-        file_key.set_contents_from_string(bytes,
-            encrypt_key=self.context.config.get('S3_STORAGE_SSE', ''),         #TODO: fix config prefix
-            reduced_redundancy=self.context.config.get('S3_STORAGE_RRS', '')   #TODO: fix config prefix
+        file_key.set_contents_from_string(
+            bytes,
+            encrypt_key=self.context.config.get('S3_STORAGE_SSE', ''),         # TODO: fix config prefix
+            reduced_redundancy=self.context.config.get('S3_STORAGE_RRS', '')   # TODO: fix config prefix
         )
 
     def get(self, path):
@@ -91,7 +93,7 @@ class AwsStorage():
 
         return self.utc_to_local(parse_ts(file_key.last_modified))
 
-    def utc_to_local(self,utc_dt):
+    def utc_to_local(self, utc_dt):
         # get integer timestamp to avoid precision lost
         timestamp = calendar.timegm(utc_dt.timetuple())
         local_dt = datetime.fromtimestamp(timestamp)

--- a/tc_aws/loaders/s3_loader.py
+++ b/tc_aws/loaders/s3_loader.py
@@ -9,6 +9,7 @@ import thumbor.loaders.http_loader as http_loader
 
 from tc_aws.aws.connection import get_connection
 
+
 def _get_bucket(url, root_path=None):
     """
     Returns a tuple containing bucket name and bucket path.

--- a/tc_aws/result_storages/s3_storage.py
+++ b/tc_aws/result_storages/s3_storage.py
@@ -4,6 +4,7 @@ from thumbor.result_storages import BaseStorage
 
 from ..aws.storage import AwsStorage
 
+
 class Storage(AwsStorage, BaseStorage):
     def __init__(self, context):
         BaseStorage.__init__(self, context)
@@ -16,7 +17,7 @@ class Storage(AwsStorage, BaseStorage):
         return path
 
     def get(self, path=None):
-        if path == None:
-            path=self.normalize_path(self.context.request.url)
+        if path is None:
+            path = self.normalize_path(self.context.request.url)
 
         return super(Storage, self).get(path)

--- a/tc_aws/storages/s3_storage.py
+++ b/tc_aws/storages/s3_storage.py
@@ -8,6 +8,7 @@ from thumbor.storages import BaseStorage
 
 from ..aws.storage import AwsStorage
 
+
 class Storage(AwsStorage, BaseStorage):
 
     def __init__(self, context):
@@ -82,5 +83,5 @@ class Storage(AwsStorage, BaseStorage):
 
         return True
 
-    def resolve_original_photo_path(self,filename):
+    def resolve_original_photo_path(self, filename):
         return filename

--- a/vows/fixtures/storage_fixture.py
+++ b/vows/fixtures/storage_fixture.py
@@ -4,7 +4,7 @@
 # thumbor imaging service
 # https://github.com/globocom/thumbor/wiki
 
-# Licensed under the MIT license: 
+# Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com timehome@corp.globo.com
 
@@ -20,10 +20,12 @@ IMAGE_PATH = join(abspath(dirname(__file__)), 'image.jpg')
 with open(IMAGE_PATH, 'r') as img:
     IMAGE_BYTES = img.read()
 
+
 def get_server(key=None):
     server_params = ServerParameters(8888, 'localhost', 'thumbor.conf', None, 'info', None)
     server_params.security_key = key
     return server_params
+
 
 def get_context(server=None, config=None, importer=None):
     if not server:

--- a/vows/loader_vows.py
+++ b/vows/loader_vows.py
@@ -19,63 +19,64 @@ from tc_aws.loaders import s3_loader
 
 s3_bucket = 'thumbor-images-test'
 
+
 @Vows.batch
 class S3LoaderVows(Vows.Context):
 
-  class CanLoadImage(Vows.Context):
-    @mock_s3
-    def topic(self):
-      conn = boto.connect_s3()
-      bucket = conn.create_bucket(s3_bucket)
+    class CanLoadImage(Vows.Context):
+        @mock_s3
+        def topic(self):
+            conn = boto.connect_s3()
+            bucket = conn.create_bucket(s3_bucket)
 
-      k = Key(bucket)
-      k.key = IMAGE_PATH
-      k.set_contents_from_string(IMAGE_BYTES)
+            k = Key(bucket)
+            k.key = IMAGE_PATH
+            k.set_contents_from_string(IMAGE_BYTES)
 
-      conf = Config()
-      conf.define('S3_LOADER_BUCKET', s3_bucket, '')
-      conf.define('S3_LOADER_ROOT_PATH', 'root_path', '')
+            conf = Config()
+            conf.define('S3_LOADER_BUCKET', s3_bucket, '')
+            conf.define('S3_LOADER_ROOT_PATH', 'root_path', '')
 
-      return Context(config=conf)
-
-    def should_load_from_s3(self, topic):
-      image = yield s3_loader.load(topic, '/'.join(['root_path', IMAGE_PATH]))
-      expect(image).to_equal(IMAGE_BYTES)
-
-  class ValidatesBuckets(Vows.Context):
-    def topic(self):
-      conf = Config()
-      conf.define('S3_ALLOWED_BUCKETS', [], '')
-
-      return Context(config=conf)
+            return Context(config=conf)
 
     def should_load_from_s3(self, topic):
-      image = yield s3_loader.load(topic, '/'.join([s3_bucket, IMAGE_PATH]))
-      expect(image).to_equal(None)
+        image = yield s3_loader.load(topic, '/'.join(['root_path', IMAGE_PATH]))
+        expect(image).to_equal(IMAGE_BYTES)
 
-  class HandlesHttpLoader(Vows.Context):
-    def topic(self):
-      conf = Config()
-      conf.define('AWS_ENABLE_HTTP_LOADER', True, '')
+    class ValidatesBuckets(Vows.Context):
+        def topic(self):
+            conf = Config()
+            conf.define('S3_ALLOWED_BUCKETS', [], '')
 
-      return Context(config=conf)
+            return Context(config=conf)
 
-    def should_redirect_to_http(self, topic):
-      with patch('thumbor.loaders.http_loader.load_sync') as mock_load_sync:
-        yield s3_loader.load(topic, 'http://foo.bar')
-        expect(mock_load_sync.called).to_be_true()
+        def should_load_from_s3(self, topic):
+            image = yield s3_loader.load(topic, '/'.join([s3_bucket, IMAGE_PATH]))
+            expect(image).to_equal(None)
 
-  class CanDetectBucket(Vows.Context):
-    def topic(self):
-      return s3_loader._get_bucket('/'.join([s3_bucket, IMAGE_PATH]))
+    class HandlesHttpLoader(Vows.Context):
+        def topic(self):
+            conf = Config()
+            conf.define('AWS_ENABLE_HTTP_LOADER', True, '')
 
-    def should_detect_bucket(self, topic):
-      expect(topic[0]).to_equal(s3_bucket)
-      expect(topic[1]).to_equal(IMAGE_PATH)
+            return Context(config=conf)
 
-  class CanNormalize(Vows.Context):
-    def topic(self):
-      return s3_loader._normalize_url('/'.join([s3_bucket, IMAGE_PATH]))
+        def should_redirect_to_http(self, topic):
+            with patch('thumbor.loaders.http_loader.load_sync') as mock_load_sync:
+                yield s3_loader.load(topic, 'http://foo.bar')
+                expect(mock_load_sync.called).to_be_true()
 
-    def should_detect_bucket(self, topic):
-      expect(topic).to_equal('/'.join([s3_bucket, IMAGE_PATH]))
+    class CanDetectBucket(Vows.Context):
+        def topic(self):
+            return s3_loader._get_bucket('/'.join([s3_bucket, IMAGE_PATH]))
+
+        def should_detect_bucket(self, topic):
+            expect(topic[0]).to_equal(s3_bucket)
+            expect(topic[1]).to_equal(IMAGE_PATH)
+
+    class CanNormalize(Vows.Context):
+        def topic(self):
+            return s3_loader._normalize_url('/'.join([s3_bucket, IMAGE_PATH]))
+
+        def should_detect_bucket(self, topic):
+            expect(topic).to_equal('/'.join([s3_bucket, IMAGE_PATH]))

--- a/vows/result_storage_vows.py
+++ b/vows/result_storage_vows.py
@@ -14,94 +14,96 @@ from tc_aws.result_storages.s3_storage import Storage
 
 s3_bucket = 'thumbor-images-test'
 
+
 class Request(object):
-  url = None
+    url = None
+
 
 class RequestHandler(object):
-  _headers = {'Content-Type': 'image/webp', 'Some-Other-Header': 'doge-header'}
+    _headers = {'Content-Type': 'image/webp', 'Some-Other-Header': 'doge-header'}
+
 
 @Vows.batch
 class S3ResultStorageVows(Vows.Context):
 
-  class CanStoreImage(Vows.Context):
-    @mock_s3
-    def topic(self):
-      self.conn = S3Connection()
-      self.conn.create_bucket(s3_bucket)
+    class CanStoreImage(Vows.Context):
+        @mock_s3
+        def topic(self):
+            self.conn = S3Connection()
+            self.conn.create_bucket(s3_bucket)
 
-      config = Config(RESULT_STORAGE_BUCKET=s3_bucket)
-      ctx = Context(config=config, server=get_server('ACME-SEC'))
-      ctx.request = Request
-      ctx.request.url = 'my-image.jpg'
+            config = Config(RESULT_STORAGE_BUCKET=s3_bucket)
+            ctx = Context(config=config, server=get_server('ACME-SEC'))
+            ctx.request = Request
+            ctx.request.url = 'my-image.jpg'
 
-      storage = Storage(ctx)
-      path = storage.put(IMAGE_BYTES)
+            storage = Storage(ctx)
+            path = storage.put(IMAGE_BYTES)
 
-      return path
+            return path
 
-    def should_be_in_catalog(self, topic):
-      expect(topic).to_equal('my-image.jpg')
+        def should_be_in_catalog(self, topic):
+            expect(topic).to_equal('my-image.jpg')
 
-  class CanGetImage(Vows.Context):
-    @mock_s3
-    def topic(self):
-      self.conn = S3Connection()
-      self.conn.create_bucket(s3_bucket)
+    class CanGetImage(Vows.Context):
+        @mock_s3
+        def topic(self):
+            self.conn = S3Connection()
+            self.conn.create_bucket(s3_bucket)
 
-      config = Config(RESULT_STORAGE_BUCKET=s3_bucket)
-      ctx = Context(config=config, server=get_server('ACME-SEC'))
-      ctx.request = Request
-      ctx.request.url = 'my-image-2.jpg'
+            config = Config(RESULT_STORAGE_BUCKET=s3_bucket)
+            ctx = Context(config=config, server=get_server('ACME-SEC'))
+            ctx.request = Request
+            ctx.request.url = 'my-image-2.jpg'
 
-      storage = Storage(ctx)
-      storage.put(IMAGE_BYTES)
+            storage = Storage(ctx)
+            storage.put(IMAGE_BYTES)
 
-      return storage.get()
+            return storage.get()
 
-    def should_not_be_null(self, topic):
-      expect(topic).not_to_be_null()
-      expect(topic).not_to_be_an_error()
+        def should_not_be_null(self, topic):
+            expect(topic).not_to_be_null()
+            expect(topic).not_to_be_an_error()
 
-    def should_have_proper_bytes(self, topic):
-      expect(topic).to_equal(IMAGE_BYTES)
+        def should_have_proper_bytes(self, topic):
+            expect(topic).to_equal(IMAGE_BYTES)
 
-  class CanGetImageWithMetadata(Vows.Context):
-    @mock_s3
-    def topic(self):
-      self.conn = S3Connection()
-      self.conn.create_bucket(s3_bucket)
+    class CanGetImageWithMetadata(Vows.Context):
+        @mock_s3
+        def topic(self):
+            self.conn = S3Connection()
+            self.conn.create_bucket(s3_bucket)
 
-      config = Config(RESULT_STORAGE_BUCKET=s3_bucket, RESULT_STORAGE_S3_STORE_METADATA=True)
-      ctx = Context(config=config, server=get_server('ACME-SEC'))
-      ctx.request_handler = RequestHandler()
-      ctx.request = Request
-      ctx.request.url = 'my-image-meta.jpg'
+            config = Config(RESULT_STORAGE_BUCKET=s3_bucket, RESULT_STORAGE_S3_STORE_METADATA=True)
+            ctx = Context(config=config, server=get_server('ACME-SEC'))
+            ctx.request_handler = RequestHandler()
+            ctx.request = Request
+            ctx.request.url = 'my-image-meta.jpg'
 
-      storage = Storage(ctx)
-      storage.put(IMAGE_BYTES)
+            storage = Storage(ctx)
+            storage.put(IMAGE_BYTES)
 
-      file_abspath = storage.normalize_path(ctx.request.url)
-      file_key = storage.storage.get_key(file_abspath)
-      return file_key.content_type, file_key.metadata, file_key.read()
+            file_abspath = storage.normalize_path(ctx.request.url)
+            file_key = storage.storage.get_key(file_abspath)
+            return file_key.content_type, file_key.metadata, file_key.read()
 
-    def should_have_proper_bytes(self, topic):
-      expect(topic[0]).to_include('image/webp')
-      expect(topic[1]).to_include('some-other-header')
-      expect(topic[2]).to_equal(IMAGE_BYTES)
+        def should_have_proper_bytes(self, topic):
+            expect(topic[0]).to_include('image/webp')
+            expect(topic[1]).to_include('some-other-header')
+            expect(topic[2]).to_equal(IMAGE_BYTES)
 
-  class HandlesStoragePrefix(Vows.Context):
-    @mock_s3
-    def topic(self):
-      self.conn = S3Connection()
-      self.conn.create_bucket(s3_bucket)
+    class HandlesStoragePrefix(Vows.Context):
+        @mock_s3
+        def topic(self):
+            self.conn = S3Connection()
+            self.conn.create_bucket(s3_bucket)
 
-      config = Config(RESULT_STORAGE_BUCKET=s3_bucket, RESULT_STORAGE_AWS_STORAGE_ROOT_PATH='tata')
-      ctx = Context(config=config, server=get_server('ACME-SEC'))
+            config = Config(RESULT_STORAGE_BUCKET=s3_bucket, RESULT_STORAGE_AWS_STORAGE_ROOT_PATH='tata')
+            ctx = Context(config=config, server=get_server('ACME-SEC'))
 
-      storage = Storage(ctx)
+            storage = Storage(ctx)
 
-      return storage.normalize_path('toto')
+            return storage.normalize_path('toto')
 
-    def should_return_the_same(self, topic):
-      expect(topic).to_equal("tata/toto")
-
+        def should_return_the_same(self, topic):
+            expect(topic).to_equal("tata/toto")

--- a/vows/storage_vows.py
+++ b/vows/storage_vows.py
@@ -16,233 +16,233 @@ from tc_aws.storages.s3_storage import Storage
 
 s3_bucket = 'thumbor-images-test'
 
+
 @Vows.batch
 class S3StorageVows(Vows.Context):
 
-  class CanStoreImage(Vows.Context):
-    @mock_s3
-    def topic(self):
-      self.conn = S3Connection()
-      bucket = self.conn.create_bucket(s3_bucket)
+    class CanStoreImage(Vows.Context):
+        @mock_s3
+        def topic(self):
+            self.conn = S3Connection()
+            bucket = self.conn.create_bucket(s3_bucket)
 
-      thumborId = IMAGE_URL % '1'
-      config=Config(STORAGE_BUCKET=s3_bucket)
-      storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
-      store = storage.put(thumborId, IMAGE_BYTES )
-      k = Key(bucket)
-      k.key = thumborId
-      result = k.get_contents_as_string()
-      return (store , result)
+            thumborId = IMAGE_URL % '1'
+            config = Config(STORAGE_BUCKET=s3_bucket)
+            storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+            store = storage.put(thumborId, IMAGE_BYTES)
+            k = Key(bucket)
+            k.key = thumborId
+            result = k.get_contents_as_string()
+            return (store, result)
 
-    def should_be_in_catalog(self, topic):
-      expect(topic[0]).to_equal(IMAGE_URL % '1')
-      expect(topic[1]).not_to_be_null()
-      expect(topic[1]).not_to_be_an_error()
-      expect(topic[1]).to_equal(IMAGE_BYTES)
+        def should_be_in_catalog(self, topic):
+            expect(topic[0]).to_equal(IMAGE_URL % '1')
+            expect(topic[1]).not_to_be_null()
+            expect(topic[1]).not_to_be_an_error()
+            expect(topic[1]).to_equal(IMAGE_BYTES)
 
-  class CanGetImage(Vows.Context):
-    @mock_s3
-    def topic(self):
-      self.conn = S3Connection()
-      self.conn.create_bucket(s3_bucket)
+    class CanGetImage(Vows.Context):
+        @mock_s3
+        def topic(self):
+            self.conn = S3Connection()
+            self.conn.create_bucket(s3_bucket)
 
-      config=Config(STORAGE_BUCKET=s3_bucket)
-      storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
-      storage.put(IMAGE_URL % '2', IMAGE_BYTES)
-      return storage.get(IMAGE_URL % '2')
+            config = Config(STORAGE_BUCKET=s3_bucket)
+            storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+            storage.put(IMAGE_URL % '2', IMAGE_BYTES)
+            return storage.get(IMAGE_URL % '2')
 
-    def should_not_be_null(self, topic):
-      expect(topic).not_to_be_null()
-      expect(topic).not_to_be_an_error()
+        def should_not_be_null(self, topic):
+            expect(topic).not_to_be_null()
+            expect(topic).not_to_be_an_error()
 
-    def should_have_proper_bytes(self, topic):
-      expect(topic).to_equal(IMAGE_BYTES)
+        def should_have_proper_bytes(self, topic):
+            expect(topic).to_equal(IMAGE_BYTES)
 
-  class CanGetImageExistance(Vows.Context):
-    @mock_s3
-    def topic(self):
-      self.conn = S3Connection()
-      self.conn.create_bucket(s3_bucket)
+    class CanGetImageExistance(Vows.Context):
+        @mock_s3
+        def topic(self):
+            self.conn = S3Connection()
+            self.conn.create_bucket(s3_bucket)
 
-      config=Config(STORAGE_BUCKET=s3_bucket)
-      storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
-      storage.put(IMAGE_URL % '3', IMAGE_BYTES)
-      return storage.exists(IMAGE_URL % '3')
+            config = Config(STORAGE_BUCKET=s3_bucket)
+            storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+            storage.put(IMAGE_URL % '3', IMAGE_BYTES)
+            return storage.exists(IMAGE_URL % '3')
 
-    def should_exists(self, topic):
-      expect(topic).to_equal(True)
+        def should_exists(self, topic):
+            expect(topic).to_equal(True)
 
-  class CanGetImageInexistance(Vows.Context):
-    @mock_s3
-    def topic(self):
-      self.conn = S3Connection()
-      self.conn.create_bucket(s3_bucket)
+    class CanGetImageInexistance(Vows.Context):
+        @mock_s3
+        def topic(self):
+            self.conn = S3Connection()
+            self.conn.create_bucket(s3_bucket)
 
-      config=Config(STORAGE_BUCKET=s3_bucket)
-      storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
-      return storage.exists(IMAGE_URL % '9999')
+            config = Config(STORAGE_BUCKET=s3_bucket)
+            storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+            return storage.exists(IMAGE_URL % '9999')
 
-    def should_not_exists(self, topic):
-      expect(topic).to_equal(False)
+        def should_not_exists(self, topic):
+            expect(topic).to_equal(False)
 
-  class CanRemoveImage(Vows.Context):
-    @mock_s3
-    def topic(self):
-      self.conn = S3Connection()
-      self.conn.create_bucket(s3_bucket)
+    class CanRemoveImage(Vows.Context):
+        @mock_s3
+        def topic(self):
+            self.conn = S3Connection()
+            self.conn.create_bucket(s3_bucket)
 
-      config=Config(STORAGE_BUCKET=s3_bucket)
-      storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
-      storage.put(IMAGE_URL % '4', IMAGE_BYTES)
-      created = storage.exists(IMAGE_URL % '4')
-      time.sleep(1)
-      storage.remove(IMAGE_URL % '4')
-      time.sleep(1)
-      return storage.exists(IMAGE_URL % '4') != created
+            config = Config(STORAGE_BUCKET=s3_bucket)
+            storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+            storage.put(IMAGE_URL % '4', IMAGE_BYTES)
+            created = storage.exists(IMAGE_URL % '4')
+            time.sleep(1)
+            storage.remove(IMAGE_URL % '4')
+            time.sleep(1)
+            return storage.exists(IMAGE_URL % '4') != created
 
-    def should_be_put_and_removed(self, topic):
-      expect(topic).to_equal(True)
+        def should_be_put_and_removed(self, topic):
+            expect(topic).to_equal(True)
 
-  class CanRemovethenPutImage(Vows.Context):
-    @mock_s3
-    def topic(self):
-      self.conn = S3Connection()
-      self.conn.create_bucket(s3_bucket)
+    class CanRemovethenPutImage(Vows.Context):
+        @mock_s3
+        def topic(self):
+            self.conn = S3Connection()
+            self.conn.create_bucket(s3_bucket)
 
-      config=Config(STORAGE_BUCKET=s3_bucket)
-      storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
-      storage.put(IMAGE_URL % '5', IMAGE_BYTES)
-      storage.remove(IMAGE_URL % '5')
-      time.sleep(1)
-      created = storage.exists(IMAGE_URL % '5')
-      time.sleep(1)
-      storage.put(IMAGE_URL % '5', IMAGE_BYTES)
-      return storage.exists(IMAGE_URL % '5') != created
+            config = Config(STORAGE_BUCKET=s3_bucket)
+            storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+            storage.put(IMAGE_URL % '5', IMAGE_BYTES)
+            storage.remove(IMAGE_URL % '5')
+            time.sleep(1)
+            created = storage.exists(IMAGE_URL % '5')
+            time.sleep(1)
+            storage.put(IMAGE_URL % '5', IMAGE_BYTES)
+            return storage.exists(IMAGE_URL % '5') != created
 
-    def should_be_put_and_removed(self, topic):
-      expect(topic).to_equal(True)
+        def should_be_put_and_removed(self, topic):
+            expect(topic).to_equal(True)
 
-  class CanReturnPath(Vows.Context):
-    @mock_s3
-    def topic(self):
-      self.conn = S3Connection()
-      self.conn.create_bucket(s3_bucket)
+    class CanReturnPath(Vows.Context):
+        @mock_s3
+        def topic(self):
+            self.conn = S3Connection()
+            self.conn.create_bucket(s3_bucket)
 
-      config=Config(STORAGE_BUCKET=s3_bucket)
-      storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
-      return storage.resolve_original_photo_path("toto")
+            config = Config(STORAGE_BUCKET=s3_bucket)
+            storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+            return storage.resolve_original_photo_path("toto")
 
-    def should_return_the_same(self, topic):
-      expect(topic).to_equal("toto")
+        def should_return_the_same(self, topic):
+            expect(topic).to_equal("toto")
 
-  class HandlesStoragePrefix(Vows.Context):
-    @mock_s3
-    def topic(self):
-      self.conn = S3Connection()
-      bucket = self.conn.create_bucket(s3_bucket)
+    class HandlesStoragePrefix(Vows.Context):
+        @mock_s3
+        def topic(self):
+            self.conn = S3Connection()
+            self.conn.create_bucket(s3_bucket)
 
-      config=Config(STORAGE_BUCKET=s3_bucket, STORAGE_AWS_STORAGE_ROOT_PATH='tata')
-      storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+            config = Config(STORAGE_BUCKET=s3_bucket, STORAGE_AWS_STORAGE_ROOT_PATH='tata')
+            storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
 
-      return storage.normalize_path('toto')
+            return storage.normalize_path('toto')
 
-    def should_return_the_same(self, topic):
-      expect(topic).to_equal("tata/toto")
+        def should_return_the_same(self, topic):
+            expect(topic).to_equal("tata/toto")
 
-  class CryptoVows(Vows.Context):
-    class RaisesIfInvalidConfig(Vows.Context):
-      @Vows.capture_error
-      @mock_s3
-      def topic(self):
-        self.conn = S3Connection()
-        self.conn.create_bucket(s3_bucket)
+    class CryptoVows(Vows.Context):
+        class RaisesIfInvalidConfig(Vows.Context):
+            @Vows.capture_error
+            @mock_s3
+            def topic(self):
+                self.conn = S3Connection()
+                self.conn.create_bucket(s3_bucket)
 
-        config=Config(STORAGE_BUCKET=s3_bucket, STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True)
-        storage = Storage(Context(config=config, server=get_server('')))
-        storage.put(IMAGE_URL % '9999', IMAGE_BYTES)
-        storage.put_crypto(IMAGE_URL % '9999')
+                config = Config(STORAGE_BUCKET=s3_bucket, STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True)
+                storage = Storage(Context(config=config, server=get_server('')))
+                storage.put(IMAGE_URL % '9999', IMAGE_BYTES)
+                storage.put_crypto(IMAGE_URL % '9999')
 
-      def should_be_an_error(self, topic):
-        expect(topic).to_be_an_error_like(RuntimeError)
-        expect(topic).to_have_an_error_message_of("STORES_CRYPTO_KEY_FOR_EACH_IMAGE can't be True if no SECURITY_KEY specified")
+            def should_be_an_error(self, topic):
+                expect(topic).to_be_an_error_like(RuntimeError)
+                expect(topic).to_have_an_error_message_of("STORES_CRYPTO_KEY_FOR_EACH_IMAGE can't be True if no SECURITY_KEY specified")
 
-    class GettingCryptoForANewImageReturnsNone(Vows.Context):
-      @mock_s3
-      def topic(self):
-        self.conn = S3Connection()
-        self.conn.create_bucket(s3_bucket)
+        class GettingCryptoForANewImageReturnsNone(Vows.Context):
+            @mock_s3
+            def topic(self):
+                self.conn = S3Connection()
+                self.conn.create_bucket(s3_bucket)
 
-        config=Config(STORAGE_BUCKET=s3_bucket, STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True)
-        storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
-        return storage.get_crypto(IMAGE_URL % '9999')
+                config = Config(STORAGE_BUCKET=s3_bucket, STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True)
+                storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+                return storage.get_crypto(IMAGE_URL % '9999')
 
-      def should_be_null(self, topic):
-        expect(topic).to_be_null()
+            def should_be_null(self, topic):
+                expect(topic).to_be_null()
 
-    class DoesNotStoreIfConfigSaysNotTo(Vows.Context):
-      @mock_s3
-      def topic(self):
-        self.conn = S3Connection()
-        self.conn.create_bucket(s3_bucket)
+        class DoesNotStoreIfConfigSaysNotTo(Vows.Context):
+            @mock_s3
+            def topic(self):
+                self.conn = S3Connection()
+                self.conn.create_bucket(s3_bucket)
 
-        config=Config(STORAGE_BUCKET=s3_bucket)
-        storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
-        storage.put(IMAGE_URL % '9998', IMAGE_BYTES)
-        storage.put_crypto(IMAGE_URL % '9998')
-        return storage.get_crypto(IMAGE_URL % '9998')
+                config = Config(STORAGE_BUCKET=s3_bucket)
+                storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+                storage.put(IMAGE_URL % '9998', IMAGE_BYTES)
+                storage.put_crypto(IMAGE_URL % '9998')
+                return storage.get_crypto(IMAGE_URL % '9998')
 
-      def should_be_null(self, topic):
-        expect(topic).to_be_null()
+            def should_be_null(self, topic):
+                expect(topic).to_be_null()
 
-    class CanStoreCrypto(Vows.Context):
-      @mock_s3
-      def topic(self):
-        self.conn = S3Connection()
-        self.conn.create_bucket(s3_bucket)
+        class CanStoreCrypto(Vows.Context):
+            @mock_s3
+            def topic(self):
+                self.conn = S3Connection()
+                self.conn.create_bucket(s3_bucket)
 
-        config=Config(STORAGE_BUCKET=s3_bucket, STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True)
-        storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
-        storage.put(IMAGE_URL % '6', IMAGE_BYTES)
-        storage.put_crypto(IMAGE_URL % '6')
-        return storage.get_crypto(IMAGE_URL % '6')
+                config = Config(STORAGE_BUCKET=s3_bucket, STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True)
+                storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+                storage.put(IMAGE_URL % '6', IMAGE_BYTES)
+                storage.put_crypto(IMAGE_URL % '6')
+                return storage.get_crypto(IMAGE_URL % '6')
 
-      def should_not_be_null(self, topic):
-        expect(topic).not_to_be_null()
-        expect(topic).not_to_be_an_error()
+            def should_not_be_null(self, topic):
+                expect(topic).not_to_be_null()
+                expect(topic).not_to_be_an_error()
 
-      def should_have_proper_key(self, topic):
-        expect(topic).to_equal('ACME-SEC')
+            def should_have_proper_key(self, topic):
+                expect(topic).to_equal('ACME-SEC')
 
-  class DetectorVows(Vows.Context):
-    class CanStoreDetectorData(Vows.Context):
-      @mock_s3
-      def topic(self):
-        self.conn = S3Connection()
-        self.conn.create_bucket(s3_bucket)
+    class DetectorVows(Vows.Context):
+        class CanStoreDetectorData(Vows.Context):
+            @mock_s3
+            def topic(self):
+                self.conn = S3Connection()
+                self.conn.create_bucket(s3_bucket)
 
-        config=Config(STORAGE_BUCKET=s3_bucket)
-        storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
-        storage.put(IMAGE_URL % '7', IMAGE_BYTES)
-        storage.put_detector_data(IMAGE_URL % '7', 'some-data')
-        return storage.get_detector_data(IMAGE_URL % '7')
+                config = Config(STORAGE_BUCKET=s3_bucket)
+                storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+                storage.put(IMAGE_URL % '7', IMAGE_BYTES)
+                storage.put_detector_data(IMAGE_URL % '7', 'some-data')
+                return storage.get_detector_data(IMAGE_URL % '7')
 
-      def should_not_be_null(self, topic):
-        expect(topic).not_to_be_null()
-        expect(topic).not_to_be_an_error()
+            def should_not_be_null(self, topic):
+                expect(topic).not_to_be_null()
+                expect(topic).not_to_be_an_error()
 
-      def should_equal_some_data(self, topic):
-        expect(topic).to_equal('some-data')
+            def should_equal_some_data(self, topic):
+                expect(topic).to_equal('some-data')
 
-    class ReturnsNoneIfNoDetectorData(Vows.Context):
-      @mock_s3
-      def topic(self):
-        self.conn = S3Connection()
-        self.conn.create_bucket(s3_bucket)
+        class ReturnsNoneIfNoDetectorData(Vows.Context):
+            @mock_s3
+            def topic(self):
+                self.conn = S3Connection()
+                self.conn.create_bucket(s3_bucket)
 
-        config=Config(STORAGE_BUCKET=s3_bucket)
-        storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
-        return storage.get_detector_data(IMAGE_URL % '9999')
+                config = Config(STORAGE_BUCKET=s3_bucket)
+                storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+                return storage.get_detector_data(IMAGE_URL % '9999')
 
-      def should_not_be_null(self, topic):
-        expect(topic).to_be_null()
-
+            def should_not_be_null(self, topic):
+                expect(topic).to_be_null()


### PR DESCRIPTION
I've fixed a few pylint warnings, regarding indentation, whitespace around operators and replacing a few equality conditions.