### PR TITLE
Using headers from context to store on meta

### DIFF
--- a/tc_aws/aws/storage.py
+++ b/tc_aws/aws/storage.py
@@ -40,7 +40,7 @@ class AwsStorage():
         file_key.key = abspath
 
         if self.config_prefix is 'RESULT_STORAGE' and self._get_config('S3_STORE_METADATA'):
-            for k, v in self.context.request_handler._headers.iteritems():
+            for k, v in self.context.headers.iteritems():
                 file_key.set_metadata(k, v)
 
         file_key.set_contents_from_string(

--- a/vows/result_storage_vows.py
+++ b/vows/result_storage_vows.py
@@ -19,10 +19,6 @@ class Request(object):
     url = None
 
 
-class RequestHandler(object):
-    _headers = {'Content-Type': 'image/webp', 'Some-Other-Header': 'doge-header'}
-
-
 @Vows.batch
 class S3ResultStorageVows(Vows.Context):
 
@@ -76,7 +72,7 @@ class S3ResultStorageVows(Vows.Context):
 
             config = Config(RESULT_STORAGE_BUCKET=s3_bucket, RESULT_STORAGE_S3_STORE_METADATA=True)
             ctx = Context(config=config, server=get_server('ACME-SEC'))
-            ctx.request_handler = RequestHandler()
+            ctx.headers = {'Content-Type': 'image/webp', 'Some-Other-Header': 'doge-header'}
             ctx.request = Request
             ctx.request.url = 'my-image-meta.jpg'
 


### PR DESCRIPTION
This PR changes the way we get response headers,
It now uses context.headers, and fixes a problem if request._headers is called after finish().