### PR TITLE
fix the delegation to the http loader

### DIFF
--- a/tc_aws/loaders/__init__.py
+++ b/tc_aws/loaders/__init__.py
@@ -4,7 +4,7 @@
 # Use of this source code is governed by the MIT license that can be
 # found in the LICENSE file.
 
-__all__ = ['_get_bucket_and_key', '_get_bucket', '_get_key', '_normalize_url', '_validate_bucket', '_use_http_loader']
+__all__ = ['_get_bucket_and_key', '_get_bucket', '_get_key', '_validate_bucket', '_use_http_loader']
 
 import urllib2
 
@@ -48,15 +48,6 @@ def _get_key(path, context):
     """
     root_path = context.config.get('TC_AWS_LOADER_ROOT_PATH')
     return '/'.join([root_path, path]) if root_path is not '' else path
-
-def _normalize_url(url):
-    """
-    Normalizes given url
-    :param string url: URL to normalize
-    :return: exactly the same url since we only use http loader if url starts with http prefix.
-    :rtype: string
-    """
-    return url
 
 def _validate_bucket(context, bucket):
     """

--- a/tc_aws/loaders/presigning_loader.py
+++ b/tc_aws/loaders/presigning_loader.py
@@ -32,13 +32,13 @@ def load(context, url, callback):
     :param callable callback: Callback method once done
     """
     if _use_http_loader(context, url):
-        http_loader.load_sync(context, url, callback, normalize_url_func=_normalize_url)
+        http_loader.load_sync(context, url, callback, normalize_url_func=http_loader._normalize_url)
     else:
         bucket, key = _get_bucket_and_key(context, url)
 
         if _validate_bucket(context, bucket):
             def on_url_generated(generated_url):
-                http_loader.load_sync(context, generated_url, callback, normalize_url_func=_normalize_url)
+                http_loader.load_sync(context, generated_url, callback, normalize_url_func=http_loader._normalize_url)
 
             _generate_presigned_url(context, bucket, key, on_url_generated)
         else:

--- a/tc_aws/loaders/s3_loader.py
+++ b/tc_aws/loaders/s3_loader.py
@@ -23,7 +23,7 @@ def load(context, url, callback):
     :param callable callback: Callback method once done
     """
     if _use_http_loader(context, url):
-        http_loader.load_sync(context, url, callback, normalize_url_func=_normalize_url)
+        http_loader.load_sync(context, url, callback, normalize_url_func=http_loader._normalize_url)
         return
 
     bucket, key = _get_bucket_and_key(context, url)

--- a/vows/loader_vows.py
+++ b/vows/loader_vows.py
@@ -52,11 +52,3 @@ class S3LoaderVows(Vows.Context):
 
         def should_detect_key(self, topic):
             expect(topic).to_equal(IMAGE_PATH)
-
-    class CanNormalize(Vows.Context):
-
-        def topic(self):
-            return _normalize_url('/'.join([s3_bucket, IMAGE_PATH]))
-
-        def should_detect_bucket(self, topic):
-            expect(topic).to_equal('/'.join([s3_bucket, IMAGE_PATH]))


### PR DESCRIPTION
looks like there has been some changes to the url handling in thumbor.

this resulted in errors when trying to fetch images from a host because it won't get formatted properly, ie:
`http%3A//127.0.0.1%3A8000/ImageTransformationTestAnimated.gif`

the implementation will now use the `_normalize_url` method of the default `http_loader`.

PTAL @heynemann @masom 