### PR TITLE
Thumbor 6 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tc_aws',
-    version='6.0.0b1',
+    version='6.0.0',
     description='Thumbor AWS extensions',
     author='Thumbor-Community & William King',
     author_email='willtrking@gmail.com',
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'python-dateutil',
-        'thumbor>=6.0.0b1',
+        'thumbor>=6.0.0',
         'tornado-botocore',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tc_aws',
-    version='2.1.1',
+    version='6.0.0b1',
     description='Thumbor AWS extensions',
     author='Thumbor-Community & William King',
     author_email='willtrking@gmail.com',
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'python-dateutil',
-        'thumbor>=5.2',
+        'thumbor>=6.0.0b1',
         'tornado-botocore',
     ],
     extras_require={

--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -96,6 +96,7 @@ class Bucket(object):
         my_session = session_handler.get_session()
         session = Botocore(service='s3', region_name=self._region,
                            operation='PutObject', session=my_session)
+
         session.call(**args)
 
     @return_future

--- a/tc_aws/aws/storage.py
+++ b/tc_aws/aws/storage.py
@@ -4,11 +4,9 @@
 # Use of this source code is governed by the MIT license that can be
 # found in the LICENSE file.
 
-import calendar
-
 from json import loads, dumps
 from os.path import join, splitext
-from datetime import datetime, timedelta
+from datetime import datetime
 from dateutil.tz import tzutc
 
 from tornado.concurrent import return_future
@@ -144,7 +142,7 @@ class AwsStorage():
                 logger.warn("[AwsStorage] s3 key not found at %s" % file_abspath)
                 callback(None)
             else:
-                callback(self._utc_to_local(file['LastModified']))
+                callback(file['LastModified'])
 
         self.storage.get(file_abspath, callback=on_file_fetched)
 
@@ -220,20 +218,6 @@ class AwsStorage():
         self.set(dumps(data), path)
 
         return path
-
-    def _utc_to_local(self, utc_dt):
-        """
-        Converts utc datetime to local datetime
-        :param datetime utc_dt:
-        :return: Local datetime
-        :rtype datetime:
-        """
-        # get integer timestamp to avoid precision lost
-        timestamp = calendar.timegm(utc_dt.timetuple())
-        local_dt  = datetime.fromtimestamp(timestamp)
-
-        assert utc_dt.resolution >= timedelta(microseconds=1)
-        return local_dt.replace(microsecond=utc_dt.microsecond)
 
     def _get_error(self, response):
         """

--- a/tc_aws/aws/storage.py
+++ b/tc_aws/aws/storage.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright (c) 2015, thumbor-community
+# Copyright (c) 2015-2016, thumbor-community
 # Use of this source code is governed by the MIT license that can be
 # found in the LICENSE file.
 
@@ -56,7 +56,8 @@ class AwsStorage():
 
         self.storage.get(file_abspath, callback=callback)
 
-    def set(self, bytes, abspath):
+    @return_future
+    def set(self, bytes, abspath, callback=None):
         """
         Stores data at given path
         :param bytes bytes: Data to store
@@ -75,10 +76,8 @@ class AwsStorage():
             metadata=metadata,
             reduced_redundancy=self.context.config.get('TC_AWS_STORAGE_RRS', False),
             encrypt_key=self.context.config.get('TC_AWS_STORAGE_SSE', False),
-            callback=self._handle_error,
+            callback=callback,
         )
-
-        return abspath
 
     def remove(self, path):
         """

--- a/tc_aws/result_storages/s3_storage.py
+++ b/tc_aws/result_storages/s3_storage.py
@@ -55,7 +55,6 @@ class Storage(AwsStorage, BaseStorage):
                 result.successful = True
                 result.metadata   = key.copy()
                 result.metadata.pop('Body')
-                result.metadata['LastModified'] = self._utc_to_local(result.metadata['LastModified'])
 
                 logger.debug(str(result.metadata))
 

--- a/tc_aws/result_storages/s3_storage.py
+++ b/tc_aws/result_storages/s3_storage.py
@@ -1,6 +1,6 @@
 #coding: utf-8
 
-# Copyright (c) 2015, thumbor-community
+# Copyright (c) 2015-2016, thumbor-community
 # Use of this source code is governed by the MIT license that can be
 # found in the LICENSE file.
 
@@ -24,18 +24,21 @@ class Storage(AwsStorage, BaseStorage):
         BaseStorage.__init__(self, context)
         AwsStorage.__init__(self, context, 'TC_AWS_RESULT_STORAGE')
 
-    def put(self, bytes):
+    @return_future
+    def put(self, bytes, callback=None):
         """
         Stores image
         :param bytes bytes: Data to store
-        :return: Path where data is stored
+        :param callable callback: Method called once done
         :rtype: string
         """
         path = self._normalize_path(self.context.request.url)
 
-        self.set(bytes, path)
+        if callback is None:
+            def callback(key):
+                self._handle_error(key)
 
-        return path
+        super(Storage, self).set(bytes, path, callback=callback)
 
     @return_future
     def get(self, path=None, callback=None):

--- a/tc_aws/storages/s3_storage.py
+++ b/tc_aws/storages/s3_storage.py
@@ -1,6 +1,6 @@
 #coding: utf-8
 
-# Copyright (c) 2015, thumbor-community
+# Copyright (c) 2015-2016, thumbor-community
 # Use of this source code is governed by the MIT license that can be
 # found in the LICENSE file.
 
@@ -22,17 +22,22 @@ class Storage(AwsStorage, BaseStorage):
         BaseStorage.__init__(self, context)
         AwsStorage.__init__(self, context, 'TC_AWS_STORAGE')
 
-    def put(self, path, bytes):
+    @return_future
+    def put(self, path, bytes, callback=None):
         """
         Stores image
         :param string path: Path to store data at
         :param bytes bytes: Data to store
-        :return: Path where data is stored
+        :param callable callback:
         :rtype: string
         """
-        self.set(bytes, self._normalize_path(path))
+        def once_written(response):
+            if response is None or self._get_error(response) is not None:
+                callback(None)
+            else:
+                callback(path)
 
-        return path
+        self.set(bytes, self._normalize_path(path), callback=once_written)
 
     @return_future
     def get(self, path, callback):

--- a/vows/result_storage_vows.py
+++ b/vows/result_storage_vows.py
@@ -26,8 +26,9 @@ class Request(object):
 class S3ResultStorageVows(Vows.Context):
 
     class CanStoreImage(Vows.Context):
+        @Vows.async_topic
         @mock_s3
-        def topic(self):
+        def topic(self, callback):
             self.conn = S3Connection()
             self.conn.create_bucket(s3_bucket)
 
@@ -37,9 +38,8 @@ class S3ResultStorageVows(Vows.Context):
             ctx.request.url = 'my-image.jpg'
 
             storage = Storage(ctx)
-            path = storage.put(IMAGE_BYTES)
 
-            return path
+            storage.put(IMAGE_BYTES, callback=callback)
 
         def should_be_in_catalog(self, topic):
             expect(topic).to_equal('my-image.jpg')


### PR DESCRIPTION
# Thumbor 6 Support

This PR aims at releasing a new version supporting Thumbor 6

## Pre-requisites
- [x] Stable v6 for thumbor

## Features
- [x] tc_aws versioning now follows thumbor's
- [x] #34 Result storage async upload

## Bug fixes
- [x] #36 Return datetime as utc
