### PR TITLE
never touch a presigned url

### DIFF
--- a/tc_aws/loaders/presigning_loader.py
+++ b/tc_aws/loaders/presigning_loader.py
@@ -38,7 +38,9 @@ def load(context, url, callback):
 
         if _validate_bucket(context, bucket):
             def on_url_generated(generated_url):
-                http_loader.load_sync(context, generated_url, callback, normalize_url_func=http_loader._normalize_url)
+                def noop(url):
+                    return url
+                http_loader.load_sync(context, generated_url, callback, normalize_url_func=noop)
 
             _generate_presigned_url(context, bucket, key, on_url_generated)
         else:


### PR DESCRIPTION
related to https://github.com/boto/botocore/issues/846 and https://github.com/thumbor-community/aws/issues/47

i finally got around to inspect the issues we had when upgrading botcore with the presigned loader.

the fix is obvious, urls genereated from botocore are signed, so they must never be touched afterwards.