### PR TITLE
Return NOT_FOUND for a disallowed bucket

### DIFF
--- a/tc_aws/loaders/s3_loader.py
+++ b/tc_aws/loaders/s3_loader.py
@@ -47,4 +47,5 @@ def load(context, url, callback):
 
         bucket_loader.get(key, callback=handle_data)
     else:
-        callback(None)
+        result = LoaderResult(successful=False, error=LoaderResult.ERROR_NOT_FOUND)
+        callback(result)


### PR DESCRIPTION
Hi,

I came across what I assume is a bug when trying to restrict access to certain buckets.

If a caller tries to access a bucket that is not in the allowed list, an exception is thrown due to the FetchResult object resulting from the load call not being properly formed.

This change brings the behaviour of the access of a disallowed bucket in line with the access of a non-existent bucket - returning a 404 Not Found.

Thanks,

Kevin.