### PR TITLE
Custom endpoint

### DIFF
--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -16,7 +16,7 @@ class Bucket(object):
     """
     _bucket      = None
     _region      = None
-    _endopint    = None
+    _endpoint    = None
     _local_cache = dict()
 
     def __init__(self, bucket, region, endpoint):

--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -38,7 +38,7 @@ class Bucket(object):
         :param string path: Path or 'key' to retrieve AWS object
         :param callable callback: Callback function for once the retrieval is done
         """
-        my_session = session_handler.get_session(self._endpoint)
+        my_session = session_handler.get_session(self._endpoint is not None)
         session = Botocore(service='s3', region_name=self._region,
                            operation='GetObject', session=my_session,
                            endpoint_url=self._endpoint)
@@ -57,7 +57,7 @@ class Bucket(object):
         :param int expiry: URL validity time
         :param callable callback: Called function once done
         """
-        session = session_handler.get_session(self._endpoint)
+        session = session_handler.get_session(self._endpoint is not None)
         client  = session.create_client('s3', region_name=self._region,
                                         endpoint_url=self._endpoint)
 
@@ -98,7 +98,7 @@ class Bucket(object):
         if encrypt_key:
             args['ServerSideEncryption'] = 'AES256'
 
-        my_session = session_handler.get_session(self._endpoint)
+        my_session = session_handler.get_session(self._endpoint is not None)
         session = Botocore(service='s3', region_name=self._region,
                            operation='PutObject', session=my_session,
                            endpoint_url=self._endpoint)
@@ -112,7 +112,7 @@ class Bucket(object):
         :param string path: Path or 'key' to delete
         :param callable callback: Called function once done
         """
-        my_session = session_handler.get_session(self._endpoint)
+        my_session = session_handler.get_session(self._endpoint is not None)
         session = Botocore(service='s3', region_name=self._region,
                            operation='DeleteObject', session=my_session,
                            endpoint_url=self._endpoint)

--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -16,17 +16,20 @@ class Bucket(object):
     """
     _bucket      = None
     _region      = None
+    _endopint    = None
     _local_cache = dict()
 
-    def __init__(self, bucket, region):
+    def __init__(self, bucket, region, endpoint):
         """
         Constructor
         :param string bucket: The bucket name
         :param string region: The AWS API region to use
+        :param string endpoint: A specific endpoint to use
         :return: The created bucket
         """
         self._bucket = bucket
         self._region = region
+        self._endpoint = endpoint
 
     @return_future
     def get(self, path, callback=None):
@@ -35,9 +38,10 @@ class Bucket(object):
         :param string path: Path or 'key' to retrieve AWS object
         :param callable callback: Callback function for once the retrieval is done
         """
-        my_session = session_handler.get_session()
+        my_session = session_handler.get_session(self._endpoint)
         session = Botocore(service='s3', region_name=self._region,
-                           operation='GetObject', session=my_session)
+                           operation='GetObject', session=my_session,
+                           endpoint_url=self._endpoint)
         session.call(
             callback=callback,
             Bucket=self._bucket,
@@ -53,8 +57,9 @@ class Bucket(object):
         :param int expiry: URL validity time
         :param callable callback: Called function once done
         """
-        session = session_handler.get_session()
-        client  = session.create_client('s3', region_name=self._region)
+        session = session_handler.get_session(self._endpoint)
+        client  = session.create_client('s3', region_name=self._region,
+                                        endpoint_url=self._endpoint)
 
         url = client.generate_presigned_url(
             ClientMethod='get_object',
@@ -93,9 +98,10 @@ class Bucket(object):
         if encrypt_key:
             args['ServerSideEncryption'] = 'AES256'
 
-        my_session = session_handler.get_session()
+        my_session = session_handler.get_session(self._endpoint)
         session = Botocore(service='s3', region_name=self._region,
-                           operation='PutObject', session=my_session)
+                           operation='PutObject', session=my_session,
+                           endpoint_url=self._endpoint)
 
         session.call(**args)
 
@@ -106,9 +112,10 @@ class Bucket(object):
         :param string path: Path or 'key' to delete
         :param callable callback: Called function once done
         """
-        my_session = session_handler.get_session()
+        my_session = session_handler.get_session(self._endpoint)
         session = Botocore(service='s3', region_name=self._region,
-                           operation='DeleteObject', session=my_session)
+                           operation='DeleteObject', session=my_session,
+                           endpoint_url=self._endpoint)
         session.call(
             callback=callback,
             Bucket=self._bucket,

--- a/tc_aws/aws/session.py
+++ b/tc_aws/aws/session.py
@@ -1,11 +1,14 @@
 import botocore.session
+from botocore.utils import fix_s3_host
 
+__all__ = ['get_session']
 
-session = None
+sessions = [None, None]
 
-
-def get_session():
-    global session
+def get_session(endpoint=None):
+    session = sessions[bool(endpoint)]
     if session is None:
-        session = botocore.session.get_session()
+        session = sessions[bool(endpoint)] = botocore.session.get_session()
+        if endpoint:
+            session.unregister('before-sign.s3', fix_s3_host)
     return session

--- a/tc_aws/aws/session.py
+++ b/tc_aws/aws/session.py
@@ -3,15 +3,18 @@ from botocore.utils import fix_s3_host
 
 __all__ = ['get_session']
 
-# We cache two sessions
-# So we have one session with the s3 host-subdomain hook for AWS connections
-# and one without the hook for custom endpoints
-sessions = [None, None]
+session = None
 
-def get_session(endpoint=None):
-    session = sessions[bool(endpoint)]
+def get_session(custom_endpoint=None):
+    '''
+    Return a session object
+    
+    :param bool custom_endpoint: If true, prevent boto fiddling with the hostname
+    :return: The session
+    '''
+    global session
     if session is None:
-        session = sessions[bool(endpoint)] = botocore.session.get_session()
-        if endpoint:
+        session = botocore.session.get_session()
+        if custom_endpoint:
             session.unregister('before-sign.s3', fix_s3_host)
     return session

--- a/tc_aws/aws/session.py
+++ b/tc_aws/aws/session.py
@@ -3,8 +3,8 @@ from botocore.utils import fix_s3_host
 
 __all__ = ['get_session']
 
-# We cache two sessions - one with a custom endpoint, one without)
-# So we have one session with the s3 signing hook for AWS connections
+# We cache two sessions
+# So we have one session with the s3 host-subdomain hook for AWS connections
 # and one without the hook for custom endpoints
 sessions = [None, None]
 

--- a/tc_aws/aws/session.py
+++ b/tc_aws/aws/session.py
@@ -5,7 +5,7 @@ __all__ = ['get_session']
 
 session = None
 
-def get_session(custom_endpoint=None):
+def get_session(custom_endpoint=False):
     '''
     Return a session object
     

--- a/tc_aws/aws/session.py
+++ b/tc_aws/aws/session.py
@@ -3,6 +3,9 @@ from botocore.utils import fix_s3_host
 
 __all__ = ['get_session']
 
+# We cache two sessions - one with a custom endpoint, one without)
+# So we have one session with the s3 signing hook for AWS connections
+# and one without the hook for custom endpoints
 sessions = [None, None]
 
 def get_session(endpoint=None):

--- a/tc_aws/aws/storage.py
+++ b/tc_aws/aws/storage.py
@@ -34,7 +34,8 @@ class AwsStorage():
         :return: The bucket
         :rtype: Bucket
         """
-        return Bucket(self._get_config('BUCKET'), self.context.config.get('TC_AWS_REGION'))
+        return Bucket(self._get_config('BUCKET'), self.context.config.get('TC_AWS_REGION'),
+                      self.context.config.get('TC_AWS_ENDPOINT'))
 
     def __init__(self, context, config_prefix):
         """

--- a/tc_aws/loaders/presigning_loader.py
+++ b/tc_aws/loaders/presigning_loader.py
@@ -20,7 +20,8 @@ def _generate_presigned_url(context, bucket, key, callback):
     :param string key: Path to get URL for
     :param callable callback: Callback method once done
     """
-    Bucket(bucket, context.config.get('TC_AWS_REGION')).get_url(key, callback=callback)
+    Bucket(bucket, context.config.get('TC_AWS_REGION'),
+           context.config.get('TC_AWS_ENDPOINT')).get_url(key, callback=callback)
 
 
 @return_future

--- a/tc_aws/loaders/s3_loader.py
+++ b/tc_aws/loaders/s3_loader.py
@@ -29,7 +29,8 @@ def load(context, url, callback):
     bucket, key = _get_bucket_and_key(context, url)
 
     if _validate_bucket(context, bucket):
-        bucket_loader = Bucket(bucket, context.config.get('TC_AWS_REGION'))
+        bucket_loader = Bucket(bucket, context.config.get('TC_AWS_REGION'),
+                               context.config.get('TC_AWS_ENDPOINT'))
 
         def handle_data(file_key):
             if not file_key or 'Error' in file_key or 'Body' not in file_key:


### PR DESCRIPTION
These changes allow a custom endpoint (e.g. an S3 compatible interface to a locally hosted service such as http://docs.ceph.com/docs/master/radosgw/s3/) to be specified in the thumbor config.

It used to be possible to specific a custom endpoint in the configuration of previous versions of boto, but not in boto3.