### PR TITLE
Make check for TC_AWS_LOADER_BUCKET less strict.

### DIFF
--- a/tc_aws/loaders/__init__.py
+++ b/tc_aws/loaders/__init__.py
@@ -19,7 +19,7 @@ def _get_bucket_and_key(context, url):
     url = urllib2.unquote(url)
 
     bucket = context.config.get('TC_AWS_LOADER_BUCKET')
-    if bucket is None:
+    if not bucket:
         bucket = _get_bucket(url)
         url = '/'.join(url.lstrip('/').split('/')[1:])
 


### PR DESCRIPTION
To support multiple buckets, TC_AWS_LOADER_BUCKET can be unset. However, any falsy value should count as "not set".

Reasoning:

1. An empty bucket name doesn't make sense.
2. Some deployment (i.e. config templating) approaches might make it difficult to set a None value.

Backwards-compatibility: Should be fine, as currently an empty bucket name raises an error anyway.

Specifically, I came across this trying to use https://github.com/APSL/docker-thumbor/blob/7a26c082146c3d6520d9eede4c8404a566bb35b0/thumbor/conf/thumbor.conf.tpl, which sets the value to an empty string.