### PR TITLE
Explicitly set content type when uploading to S3

### DIFF
--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -8,6 +8,7 @@ import session as session_handler
 from tornado_botocore import Botocore
 from tornado.concurrent import return_future
 from thumbor.utils import logger
+from thumbor.engines import BaseEngine
 
 
 class Bucket(object):
@@ -85,12 +86,14 @@ class Bucket(object):
         :param callable callback: Called function once done
         """
         storage_class = 'REDUCED_REDUNDANCY' if reduced_redundancy else 'STANDARD'
+        content_type = BaseEngine.get_mimetype(data) or 'application/octet-stream'
 
         args = dict(
             callback=callback,
             Bucket=self._bucket,
             Key=self._clean_key(path),
             Body=data,
+            ContentType=content_type,
             Metadata=metadata,
             StorageClass=storage_class,
         )


### PR DESCRIPTION
S3 was defaulting to application/octet-stream on all files uploaded. So if you hit S3 directly from a browser, the image downloads.

This PR explicitly sets the content type when uploading to S3.

I am using this in a scenario where I have Cloudfront using an S3 static website as the origin instead of Thumbor directly. S3 is configured to redirect 404 errors to the actual Thumbor server. This way, cached result images can be served directly by S3 and Cloudfront.