### PR TITLE
Allow unicode URLs to be resized

### DIFF
--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -126,7 +126,7 @@ class Bucket(object):
         )
 
     def _clean_key(self, path):
-        logger.debug('Cleaning key: {path}'.format(path=path))
+        logger.debug('Cleaning key: {path!r}'.format(path=path))
         key = path
         while '//' in key:
             logger.debug(key)
@@ -135,5 +135,5 @@ class Bucket(object):
         if '/' == key[0]:
             key = key[1:]
 
-        logger.debug('Cleansed key: {key}'.format(key=key))
+        logger.debug('Cleansed key: {key!r}'.format(key=key))
         return key


### PR DESCRIPTION
In https://github.com/thumbor-community/aws/issues/95 we found that URLs with unicode characters, such as the registered trademark character ® character, `%C2%AE` when url-encoded, failed to resize. The error was a result of the logger lines which failed to encode the path.

This change switches the logger lines to be the representation of the object, which is ASCII based. For the registered trademark character, the log lines will display `\xae` instead. S3 accepts unicode characters in paths, so no further changes are needed to get the image to save and load.

An alternative fix option to have log line to match the S3 path is to encode `path`upon entering `_clean_key()`, but I wasn't sure of the repercussions of that upgrade in live environments.