### PR TITLE
Import Botocore from a more specific location

### DIFF
--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -5,7 +5,7 @@
 # found in the LICENSE file.
 
 import session as session_handler
-from tornado_botocore import Botocore
+from tornado_botocore.base import Botocore
 from tornado.concurrent import return_future
 from thumbor.utils import logger
 from thumbor.engines import BaseEngine


### PR DESCRIPTION
Importing Botocore directly from `tornado_botocore.base` allows us to bypass the vague error message given by the library and see the actual import failure.
Fixes #99