### PR TITLE
Update bucket.py to prevent error

### DIFF
--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -143,8 +143,11 @@ class Bucket(object):
             logger.debug(key)
             key = key.replace('//', '/')
 
-        if '/' == key[0]:
-            key = key[1:]
+        try:
+            if '/' == key[0]:
+                key = key[1:]
+        except IndexError:
+            pass
 
         logger.debug('Cleansed key: {key!r}'.format(key=key))
         return key

--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -142,12 +142,8 @@ class Bucket(object):
         while '//' in key:
             logger.debug(key)
             key = key.replace('//', '/')
-
-        try:
-            if '/' == key[0]:
-                key = key[1:]
-        except IndexError:
-            pass
+        if key.startswith('/'):
+            key = key.replace('/', '', 1)
 
         logger.debug('Cleansed key: {key!r}'.format(key=key))
         return key

--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -142,6 +142,7 @@ class Bucket(object):
         while '//' in key:
             logger.debug(key)
             key = key.replace('//', '/')
+        
         if key.startswith('/'):
             key = key.replace('/', '', 1)
 


### PR DESCRIPTION
Fixes 

```
File "project/venv/lib/python2.7/site-packages/tornado/gen.py", line 307, in wrapper
    yielded = next(result)
  File "project/venv/lib/python2.7/site-packages/thumbor-6.5.1-py2.7-macosx-10.13-x86_64.egg/thumbor/handlers/imaging.py", line 31, in check_image
    exists = yield gen.maybe_future(self.context.modules.storage.exists(kw['image'][:self.context.config.MAX_ID_LENGTH]))
  File "project/venv/lib/python2.7/site-packages/tornado/concurrent.py", line 483, in wrapper
    future.result()
  File "project/venv/lib/python2.7/site-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "project/venv/lib/python2.7/site-packages/tornado/concurrent.py", line 471, in wrapper
    result = f(*args, **kwargs)
  File "project/venv/lib/python2.7/site-packages/tc_aws/aws/storage.py", line 109, in exists
    self.storage.get(file_abspath, callback=return_data)
  File "project/venv/lib/python2.7/site-packages/tornado/concurrent.py", line 483, in wrapper
    future.result()
  File "project/venv/lib/python2.7/site-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "project/venv/lib/python2.7/site-packages/tornado/concurrent.py", line 471, in wrapper
    result = f(*args, **kwargs)
  File "project/venv/lib/python2.7/site-packages/tc_aws/aws/bucket.py", line 71, in get
    Key=self._clean_key(path),
  File "project/venv/lib/python2.7/site-packages/tc_aws/aws/bucket.py", line 146, in _clean_key
    if '/' == key[0]:
IndexError: string index out of range
```