### PR TITLE
Fix the bug that can not remove the file on aws

### DIFF
--- a/tc_aws/aws/storage.py
+++ b/tc_aws/aws/storage.py
@@ -81,15 +81,13 @@ class AwsStorage():
             callback=callback,
         )
 
-    def remove(self, path):
+    @return_future
+    def remove(self, path, callback=None):
         """
         Deletes data at path
         :param string path: Path to delete
-        :return: Whether deletion is successful or not
-        :rtype: bool
         """
-        yield self.storage.delete(path)
-        return
+        self.storage.delete(path)
 
     @return_future
     def exists(self, path, callback):

--- a/vows/storage_vows.py
+++ b/vows/storage_vows.py
@@ -99,16 +99,8 @@ class S3StorageVows(Vows.Context):
             config = Config(TC_AWS_STORAGE_BUCKET=s3_bucket)
             storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
             storage.put(IMAGE_URL % '4', IMAGE_BYTES)   # 1: we put the image
-
-            def check_created(created):
-                expect(created).to_equal(True) # 2.1: assertion...
-
-                def once_removed(rm):
-                    storage.exists(IMAGE_URL % '4', callback=callback) #4: we check if the image exists
-
-                storage.remove(IMAGE_URL % '4', callback=once_removed) # 3: we delete it
-
-            storage.exists(IMAGE_URL % '4', callback=check_created) # 2: we check it exists
+            storage.remove(IMAGE_URL % '4') # 2: we delete it
+            storage.exists(IMAGE_URL % '4', callback=callback) # 3: we check it exists
 
         def should_be_put_and_removed(self, topic):
             expect(topic.args[0]).to_equal(False)   # 4.1: assertion...


### PR DESCRIPTION
This fix is used to fix the Issue #123 , which I found that you can't delete the file when using delete api. As the remove() without decorator @return_future, and it will never be executed.
My test environment:
`Python 2.7.13 `

You can easily test by using localstack.
```
pip install localstack thumbor==6.1.5 botocore==1.5.70 tc-aws==6.2.10
export SERVICES=s3
export DEBUG=1
localstack start
``` 

create a 'test' bucket on localstack.
```
import boto3
s3 = boto3.client('s3', endpoint_url='http://localhost:4572', use_ssl=False)
s3.create_bucket(Bucket='test')
```
change thumbor.conf using localstack s3.
`TC_AWS_ENDPOINT='http://localhost:4572'`

Upload and image to 'test' bucket and then delete.



