### PR TITLE
Use aiobotocore 2.2.0 to support assume role credentials

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     install_requires=[
         'python-dateutil',
         'thumbor>=7.0.0a2,<8',
-        'aiobotocore==0.12.0',
+        'aiobotocore==2.2.0',
     ],
     extras_require={
         'tests': [
@@ -66,6 +66,7 @@ setup(
             'moto[server]',
             'mock',
             'pytest',
+            'pytest-asyncio'
         ],
     },
 )

--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -53,10 +53,12 @@ class Bucket(object):
         :param string path: Path or 'key' to retrieve AWS object
         """
         try:
-            await self._client.head_object(
-                Bucket=self._bucket,
-                Key=self._clean_key(path),
-            )
+            async with aiobotocore.session.get_session().create_client('s3', region_name=self.region_name,
+                                                                       endpoint_url=self.endpoint_url) as s3_client:
+                await s3_client.head_object(
+                    Bucket=self._bucket,
+                    Key=self._clean_key(path),
+                )
         except Exception:
             return False
         return True

--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -56,8 +56,8 @@ class Bucket(object):
         :param string path: Path or 'key' to retrieve AWS object
         """
         try:
-            async with aiobotocore.session.get_session().create_client('s3', region_name=self.region_name,
-                                                                       endpoint_url=self.endpoint_url) as s3_client:
+            async with self.session.create_client('s3', region_name=self.region_name,
+                                                  endpoint_url=self.endpoint_url) as s3_client:
                 await s3_client.head_object(
                     Bucket=self._bucket,
                     Key=self._clean_key(path),
@@ -89,8 +89,8 @@ class Bucket(object):
         :param string method: Method for requested URL
         :param int expiry: URL validity time
         """
-        async with aiobotocore.session.get_session().create_client('s3', region_name=self.region_name,
-                                                                   endpoint_url=self.endpoint_url) as s3_client:
+        async with self.session.create_client('s3', region_name=self.region_name,
+                                              endpoint_url=self.endpoint_url) as s3_client:
             url = await s3_client.generate_presigned_url(
                 ClientMethod='get_object',
                 Params={
@@ -129,8 +129,8 @@ class Bucket(object):
         if metadata is not None:
             args['Metadata'] = metadata
 
-        async with aiobotocore.session.get_session().create_client('s3', region_name=self.region_name,
-                                                                   endpoint_url=self.endpoint_url) as s3_client:
+        async with self.session.create_client('s3', region_name=self.region_name,
+                                              endpoint_url=self.endpoint_url) as s3_client:
             return await s3_client.put_object(**args)
 
     async def delete(self, path):
@@ -138,8 +138,8 @@ class Bucket(object):
         Deletes key at given path
         :param string path: Path or 'key' to delete
         """
-        async with aiobotocore.session.get_session().create_client('s3', region_name=self.region_name,
-                                                                   endpoint_url=self.endpoint_url) as s3_client:
+        async with self.session.create_client('s3', region_name=self.region_name,
+                                              endpoint_url=self.endpoint_url) as s3_client:
             return await s3_client.delete_object(
                 Bucket=self._bucket,
                 Key=self._clean_key(path),

--- a/tc_aws/loaders/s3_loader.py
+++ b/tc_aws/loaders/s3_loader.py
@@ -63,8 +63,9 @@ async def load(context, url):
         return result
 
     result.successful = True
-    async with file_key['Body'] as stream:
-        result.buffer = await stream.read()
+    with file_key['Body'] as stream:
+        result.buffer = stream.read()
+        del stream
 
     result.metadata.update(
         size=file_key['ContentLength'],

--- a/tc_aws/result_storages/s3_storage.py
+++ b/tc_aws/result_storages/s3_storage.py
@@ -60,8 +60,10 @@ class Storage(AwsStorage, BaseStorage):
             return None
 
         result = ResultStorageResult()
-        async with key['Body'] as stream:
-            result.buffer = await stream.read()
+        with key['Body'] as stream:
+            result.buffer = stream.read()
+            del stream
+
         result.successful = True
 
         result.metadata = {

--- a/tc_aws/storages/s3_storage.py
+++ b/tc_aws/storages/s3_storage.py
@@ -109,8 +109,9 @@ class Storage(AwsStorage, BaseStorage):
             logger.warn("[STORAGE] s3 key not found at %s" % crypto_path)
             return None
 
-        async with file_key['Body'] as stream:
-            file_key = await stream.read()
+        with file_key['Body'] as stream:
+            file_key = stream.read()
+            del stream
 
         return file_key.decode('utf-8')
 
@@ -130,8 +131,8 @@ class Storage(AwsStorage, BaseStorage):
         if not file_key or self.is_expired(file_key) or 'Body' not in file_key:
             return None
 
-        async with file_key['Body'] as stream:
-            return loads(await stream.read())
+        with file_key['Body'] as stream:
+            return loads(stream.read())
 
     async def get(self, path):
         """
@@ -144,8 +145,8 @@ class Storage(AwsStorage, BaseStorage):
         except BotoCoreError:
             return None
 
-        async with file['Body'] as stream:
-            return await stream.read()
+        with file['Body'] as stream:
+            return stream.read()
 
     async def exists(self, path):
         """


### PR DESCRIPTION
## Scenario

This PR bumps aiobotocore to its latest version (2.2.0), allowing to authenticate using IAM Roles/WebIdentity credentials with thumbor-aws.

## What has been Done

- [x] chore: Updated tests and implementation to use aiobotocore 2.2.0.
