### PR TITLE
comparison-syntax-warning

### DIFF
--- a/tc_aws/loaders/s3_loader.py
+++ b/tc_aws/loaders/s3_loader.py
@@ -115,7 +115,7 @@ def _get_key(path, context):
     :rtype: string
     """
     root_path = context.config.get('TC_AWS_LOADER_ROOT_PATH')
-    return '/'.join([root_path, path]) if root_path is not '' else path
+    return '/'.join([root_path, path]) if root_path != '' else path
 
 
 def _validate_bucket(context, bucket):


### PR DESCRIPTION
[As of Python 3.8](https://docs.astral.sh/ruff/rules/is-literal/), using `is` and `is not` with constant literals will produce a SyntaxWarning.

```
thumbor-1        | /usr/lib/python3.10/site-packages/tc_aws/loaders/s3_loader.py:118: SyntaxWarning: "is not" with a literal. Did you mean "!="?
thumbor-1        |   return '/'.join([root_path, path]) if root_path is not '' else path
```