### PR TITLE
fix: storage.get return None instead of raise the NoSuchKey error

### DIFF
--- a/tc_aws/storages/s3_storage.py
+++ b/tc_aws/storages/s3_storage.py
@@ -141,7 +141,7 @@ class Storage(AwsStorage, BaseStorage):
 
         try:
             file = await super(Storage, self).get(path)
-        except BotoCoreError:
+        except ClientError:
             return None
         except ClientError as e:
             # in case there is no key found we need to return None,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -52,6 +52,15 @@ class S3StorageTestCase(S3MockedAsyncTestCase):
         self.assertFalse(topic)
 
     @gen_test
+    async def test_getting_inexistante_image_return_none(self):
+        config = Config(TC_AWS_STORAGE_BUCKET=s3_bucket)
+        storage = Storage(Context(config=config, server=get_server('ACME-SEC')))
+
+        topic = await storage.get(IMAGE_URL % '9999')
+
+        self.assertIsNone(topic)
+
+    @gen_test
     async def test_can_remove_instance(self):
         config = Config(TC_AWS_STORAGE_BUCKET=s3_bucket,TC_AWS_STORAGE_ROOT_PATH='nana')
         storage = Storage(Context(config=config, server=get_server('ACME-SEC')))


### PR DESCRIPTION
Tested Thumbor 7.7.4, when `STORAGE = 'tc_aws.storages.s3_storage'` it crashes due to a `botocore.errorfactory.NoSuchKey` error.

Also become a little bit more consistent with result storage's get method which does the same.