### PR TITLE
feat!: bump to aiobotocore 2.23.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,13 +58,13 @@ setup(
     install_requires=[
         'python-dateutil>=2.8',
         'thumbor>=7.0.0a2,<8',
-        'aiobotocore==0.12.0',
-        'boto3>=1.9,<1.13',
+        'aiobotocore==2.23.0',
+        'boto3>=1.38.0,<1.39.0',
     ],
     extras_require={
         'tests': [
             'coverage>=6.5',
-            'moto[server]>=4.0',
+            'moto[server]>=5.0.0,<6.0.0',
             'mock>=4.0',
             'pytest>=7.2',
         ],


### PR DESCRIPTION
## Context

The actual version of aiobotocore, 0.12.0, is five years old.

In some cases (like https://github.com/aio-libs/aiobotocore/pull/659), it produces errors like:
```
cannot pickle coroutine object
coroutine AioBaseClient._make_api_call was never awaited
```

These errors have been fixed since then.

Furthermore, installation of the dependencies take longer due to long search to find the compatible versions.

## Suggestion

Let's update aiobotocore to its last available versions, right now 2.23.0.

There have been some breaking changes in aiobotocore like `API breaking: The result of create_client is now a required async context class` in [1.0.0](https://github.com/aio-libs/aiobotocore/releases/tag/1.0.0)

The naïve implementation of re-using the session and using context manager to create a new client each time like
```python
    async with self._session.create_client('s3', ...) as client:
        resp = await client.put_object(Bucket=bucket, Key=key, Body=data)
```

is degrading performance at the point of having difficulties to support 50 requests per second during 60s (response time increases)

So I chose to use an asynchronous context manager to continue being able to reuse the client.
